### PR TITLE
setting correct return status for GOLD_NEMAX operator

### DIFF
--- a/obs_def/obs_def_GOLD_mod.f90
+++ b/obs_def/obs_def_GOLD_mod.f90
@@ -146,7 +146,12 @@ enddo LEVELS
 
 if (nAlts == 0) return
 
-nemax = maxval(IDensityS_ie(1:nAlts))
+! istatus is guaranteed to have a failure status (the only way to exit the
+! "LEVELS" loop). Since we got this far, we need to reset the status to
+! indicate a successful forward operator.
+
+istatus = 0
+nemax   = maxval(IDensityS_ie(1:nAlts))
 obs_val = nemax
 
 end subroutine get_expected_nemax


### PR DESCRIPTION
same problem we had with the other forward operator. The code is working, but not setting the right return value. Without a 'successful' forward operator, DART assigns this as a 'failed forward operator'.